### PR TITLE
🧑‍💻 Set up the code quality tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ __pycache__/
 build/
 dist/
 *.egg-info/
+
+# Mypy
+.mypy_cache/
+
+# Ruff
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,22 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: '23.10.1'
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.6.1'
+    hooks:
+      - id: mypy
+        exclude: '^(?:(?!src).)*$'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.1.3'
+    hooks:
+      - id: ruff
+        args:
+          - --fix
+          - --exit-non-zero-on-fix
 
 ci:
   autofix_commit_msg:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=flat-square&logo=pre-commit)][pre-commit.ci]
 
+[![ruff](https://img.shields.io/endpoint?style=flat-square&url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
+[![mypy](https://img.shields.io/badge/type--checked-mypy-blue?style=flat-square)][mypy]
+[![black](https://img.shields.io/badge/code%20style-black-black?style=flat-square)][black]
+
 ## Summary
 
 This package provides a few simple utilities to apply the official
@@ -25,9 +29,12 @@ Created by Kamil Paduszyński ([@paduszyk][github-paduszyk]).
 
 Released under the [MIT License][license].
 
+[black]: https://github.com/psf/black
 [github-carlosquesta]: https://github.com/carloscuesta
 [github-paduszyk]: https://github.com/paduszyk
 [gitmoji-repository]: https://github.com/carloscuesta/gitmoji
 [gitmoji-website]: https://gitmoji.dev
 [license]: https://github.com/paduszyk/python-gitmojis/blob/main/LICENSE
+[mypy]: https://github.com/python/mypy
 [pre-commit.ci]: https://results.pre-commit.ci/latest/github/paduszyk/python-gitmojis/main
+[ruff]: https://github.com/astral-sh/ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ dependencies = []
 dev = [
   "pre-commit",
 ]
+lint = [
+  "black",
+  "mypy",
+  "ruff",
+]
 
 [tool.setuptools.packages.find]
 include = ["gitmojis*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,60 @@ lint = [
 [tool.setuptools.packages.find]
 include = ["gitmojis*"]
 where = ["src"]
+
+# Black
+# https://black.readthedocs.io/en/stable/usage_and_configuration/
+
+[tool.black]
+line-length = 88
+target-version = ["py312", "py311", "py310"]
+
+# Mypy
+# https://mypy.readthedocs.io/en/stable/config_file.html
+
+[tool.mypy]
+exclude = [
+  '^(?:(?!src).)*$',
+]
+show_error_codes = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_configs = true
+
+# Ruff
+# https://docs.astral.sh/ruff/configuration/
+# https://docs.astral.sh/ruff/rules/
+# https://docs.astral.sh/ruff/settings/
+
+[tool.ruff]
+select = [
+  "F",     # pyflakes
+  "E",     # pycodestyle (errors)
+  "W",     # pycodestyle (warnings)
+  "I",     # isort
+  "N",     # pep8-naming
+  "D",     # pydocstyle
+  "B",     # flake8-bugbear
+  "A",     # flake8-builtins
+  "C4",    # flake8-comprehensions
+  "T20",   # flake8-print
+  "Q",     # flake8-quotes
+  "PTH",   # flake8-use-pathlib
+]
+ignore = ["E501", "N818", "D1", "D205"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.isort]
+known-first-party = ["gitmojis"]


### PR DESCRIPTION
## Description

This adds and configures:

* code formatter ([`black`][black]),
* type-checker ([`mypy`][mypy]),
* linter ([`ruff`][ruff])

as the basic code quality tools applied to the project's codebase.

[black]: https://github.com/psf/black
[mypy]: https://github.com/python/mypy
[ruff]: https://github.com/astral-sh/ruff
