### PR TITLE
💥 Enable fetching Gitmoji data from the official API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
     hooks:
       - id: mypy
         exclude: '^(?:(?!src).)*$'
+        additional_dependencies:
+          - types-requests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.1.3'
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ build-backend = "setuptools.build_meta"
 name = "python-gitmojis"
 version = "0.0.0"
 requires-python = ">= 3.10"
-dependencies = []
+dependencies = [
+  "requests",
+]
 
 [project.optional-dependencies]
 dev = [
@@ -20,6 +22,7 @@ lint = [
   "black",
   "mypy",
   "ruff",
+  "types-requests",
 ]
 test = [
   "pytest",

--- a/src/gitmojis/__init__.py
+++ b/src/gitmojis/__init__.py
@@ -1,6 +1,8 @@
+from .core import fetch_guide
 from .model import Gitmoji, Guide
 
 __all__ = [
     "Gitmoji",
     "Guide",
+    "fetch_guide",
 ]

--- a/src/gitmojis/core.py
+++ b/src/gitmojis/core.py
@@ -1,0 +1,19 @@
+from typing import Final
+
+import requests
+
+from .model import Gitmoji, Guide
+
+GITMOJI_API_URL: Final = "https://gitmoji.dev/api/gitmojis"
+
+GITMOJI_API_KEY: Final = "gitmojis"
+
+
+def fetch_guide() -> Guide:
+    response = requests.get(GITMOJI_API_URL)
+
+    gitmojis_json = response.json()[GITMOJI_API_KEY]
+
+    guide = Guide(gitmojis=[Gitmoji(**gitmoji_json) for gitmoji_json in gitmojis_json])
+
+    return guide

--- a/src/gitmojis/core.py
+++ b/src/gitmojis/core.py
@@ -6,6 +6,17 @@ from .model import Gitmoji, Guide
 
 
 def fetch_guide() -> Guide:
+    """Fetch the Gitmoji guide from the official Gitmoji API.
+
+    This function sends a GET request to the Gitmoji API to retrieve the current state
+    of the Gitmoji guide.
+
+    Returns:
+        A `Guide` object representing the current state of the Gitmoji API.
+
+    Raises:
+        ResponseJsonError: If the API response doesn't contain the expected JSON data.
+    """
     response = requests.get(defaults.GITMOJI_API_URL)
 
     if (gitmojis_json := response.json().get(defaults.GITMOJI_API_KEY)) is None:

--- a/src/gitmojis/core.py
+++ b/src/gitmojis/core.py
@@ -1,19 +1,14 @@
-from typing import Final
-
 import requests
 
+from . import defaults
 from .exceptions import ResponseJsonError
 from .model import Gitmoji, Guide
 
-GITMOJI_API_URL: Final = "https://gitmoji.dev/api/gitmojis"
-
-GITMOJI_API_KEY: Final = "gitmojis"
-
 
 def fetch_guide() -> Guide:
-    response = requests.get(GITMOJI_API_URL)
+    response = requests.get(defaults.GITMOJI_API_URL)
 
-    if (gitmojis_json := response.json().get(GITMOJI_API_KEY)) is None:
+    if (gitmojis_json := response.json().get(defaults.GITMOJI_API_KEY)) is None:
         raise ResponseJsonError
 
     guide = Guide(gitmojis=[Gitmoji(**gitmoji_json) for gitmoji_json in gitmojis_json])

--- a/src/gitmojis/core.py
+++ b/src/gitmojis/core.py
@@ -2,6 +2,7 @@ from typing import Final
 
 import requests
 
+from .exceptions import ResponseJsonError
 from .model import Gitmoji, Guide
 
 GITMOJI_API_URL: Final = "https://gitmoji.dev/api/gitmojis"
@@ -12,7 +13,8 @@ GITMOJI_API_KEY: Final = "gitmojis"
 def fetch_guide() -> Guide:
     response = requests.get(GITMOJI_API_URL)
 
-    gitmojis_json = response.json()[GITMOJI_API_KEY]
+    if (gitmojis_json := response.json().get(GITMOJI_API_KEY)) is None:
+        raise ResponseJsonError
 
     guide = Guide(gitmojis=[Gitmoji(**gitmoji_json) for gitmoji_json in gitmojis_json])
 

--- a/src/gitmojis/defaults.py
+++ b/src/gitmojis/defaults.py
@@ -1,0 +1,5 @@
+from typing import Final
+
+GITMOJI_API_URL: Final = "https://gitmoji.dev/api/gitmojis"
+
+GITMOJI_API_KEY: Final = "gitmojis"

--- a/src/gitmojis/exceptions.py
+++ b/src/gitmojis/exceptions.py
@@ -1,0 +1,13 @@
+class GitmojisException(Exception):
+    message: str
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or getattr(self.__class__, "message", ""))
+
+
+class ApiError(GitmojisException):
+    pass
+
+
+class ResponseJsonError(ApiError):
+    message = "unsupported format of the JSON data returned by the API"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,8 @@
 import pytest
 import requests
 
-from gitmojis.core import GITMOJI_API_KEY, fetch_guide
+from gitmojis import defaults
+from gitmojis.core import fetch_guide
 from gitmojis.exceptions import ResponseJsonError
 from gitmojis.model import Guide
 
@@ -12,7 +13,7 @@ def response(mocker):
 
 
 def test_fetch_guide_creates_guide_from_api_response_json(mocker, response):
-    response.json.return_value = {GITMOJI_API_KEY: []}
+    response.json.return_value = {defaults.GITMOJI_API_KEY: []}
 
     mocker.patch("requests.get", return_value=response)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 from gitmojis.core import GITMOJI_API_KEY, fetch_guide
+from gitmojis.exceptions import ResponseJsonError
 from gitmojis.model import Guide
 
 
@@ -18,3 +19,12 @@ def test_fetch_guide_creates_guide_from_api_response_json(mocker, response):
     guide = fetch_guide()
 
     assert isinstance(guide, Guide)
+
+
+def test_fetch_guide_raises_error_if_gitmoji_api_key_not_in_response_json(mocker, response):  # fmt: skip
+    response.json.return_value = {}  # `GITMOJI_API_KEY` not in the response's JSON
+
+    mocker.patch("requests.get", return_value=response)
+
+    with pytest.raises(ResponseJsonError):
+        fetch_guide()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,20 @@
+import pytest
+import requests
+
+from gitmojis.core import GITMOJI_API_KEY, fetch_guide
+from gitmojis.model import Guide
+
+
+@pytest.fixture()
+def response(mocker):
+    return mocker.Mock(spec_set=requests.Response)
+
+
+def test_fetch_guide_creates_guide_from_api_response_json(mocker, response):
+    response.json.return_value = {GITMOJI_API_KEY: []}
+
+    mocker.patch("requests.get", return_value=response)
+
+    guide = fetch_guide()
+
+    assert isinstance(guide, Guide)


### PR DESCRIPTION
## Description

This adds the `gitmojis.core` module with a definition of the `fetch_guide` function. The function sends a GET request to the official Gitmoji [API][api] and fetches the Gitmoji guide from the response's JSON data.

The introduced changes use the [`requests`][requests] library.

[api]: https://github.com/carloscuesta/gitmoji/tree/master/packages/gitmojis#api
[requests]: https://requests.readthedocs.io