### PR TITLE
🧑‍💻 Set up the package's CLI for adding commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ name = "python-gitmojis"
 version = "0.0.0"
 requires-python = ">= 3.10"
 dependencies = [
+  "click",
   "requests",
 ]
 
@@ -26,6 +27,7 @@ lint = [
 ]
 test = [
   "pytest",
+  "pytest-click",
   "pytest-cov",
   "pytest-custom-exit-code",
   "pytest-mock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ test = [
   "pytest-mock",
 ]
 
+[project.scripts]
+"gitmojis" = "gitmojis.__main__:main"
+
 [tool.setuptools.packages.find]
 include = ["gitmojis*"]
 where = ["src"]

--- a/src/gitmojis/__main__.py
+++ b/src/gitmojis/__main__.py
@@ -1,0 +1,4 @@
+from gitmojis.cli import gitmojis_cli as main
+
+if __name__ == "__main__":
+    main()

--- a/src/gitmojis/cli/__init__.py
+++ b/src/gitmojis/cli/__init__.py
@@ -3,8 +3,20 @@ import click
 from gitmojis.core import fetch_guide
 
 
+def get_commands() -> list[click.Command]:
+    """Return a list of `@click` commands defined in `gitmojis.cli.commands`."""
+    from gitmojis.cli import commands as commands_module
+
+    return [
+        command
+        for command in commands_module.__dict__.values()
+        if isinstance(command, click.Command)
+    ]
+
+
 @click.group(
     name="gitmojis",
+    commands=get_commands(),
 )
 @click.version_option(
     package_name="python-gitmojis",

--- a/src/gitmojis/cli/__init__.py
+++ b/src/gitmojis/cli/__init__.py
@@ -1,0 +1,20 @@
+import click
+
+from gitmojis.core import fetch_guide
+
+
+@click.group(
+    name="gitmojis",
+)
+@click.version_option(
+    package_name="python-gitmojis",
+    prog_name="gitmojis",
+)
+@click.pass_context
+def gitmojis_cli(context: click.Context) -> None:
+    """Command-line interface for managing the official Gitmoji guide."""
+    # Initialize the context object
+    context.ensure_object(dict)
+
+    # Pass the current state of the Gitmoji guide to the group context
+    context.obj["guide"] = fetch_guide()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,17 @@
+import subprocess
+import sys
+
 import click
 
 from gitmojis.cli import commands as commands_module
 from gitmojis.cli import get_commands, gitmojis_cli
 from gitmojis.model import Guide
+
+
+def test_gitmojis_cli_runs_from_package_main_module():
+    result = subprocess.run([sys.executable, "-m", "gitmojis"])
+
+    assert result.returncode == 0
 
 
 def test_get_commands_registers_command_from_commands_module(mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ def test_gitmojis_cli_runs_as_entry_point():
     assert result.returncode == 0
 
 
-def test_gitmojis_cli_runs_from_package_main_module():
+def test_gitmojis_cli_runs_as_python_script():
     result = subprocess.run([sys.executable, "-m", "gitmojis"])
 
     assert result.returncode == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,12 @@ from gitmojis.cli import get_commands, gitmojis_cli
 from gitmojis.model import Guide
 
 
+def test_gitmojis_cli_runs_as_entry_point():
+    result = subprocess.run(["gitmojis"])
+
+    assert result.returncode == 0
+
+
 def test_gitmojis_cli_runs_from_package_main_module():
     result = subprocess.run([sys.executable, "-m", "gitmojis"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,19 @@
+import click
+
+from gitmojis.cli import gitmojis_cli
+from gitmojis.model import Guide
+
+
+def test_gitmojis_cli_passes_guide_to_context(mocker, cli_runner):
+    mocker.patch("gitmojis.core.fetch_guide", return_value=Guide(gitmojis=[]))
+
+    @click.command()
+    @click.pass_context
+    def command(context):
+        assert "guide" in context.obj
+
+    gitmojis_cli.add_command(command)
+
+    result = cli_runner.invoke(gitmojis_cli, "command")
+
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,20 @@
 import click
 
-from gitmojis.cli import gitmojis_cli
+from gitmojis.cli import commands as commands_module
+from gitmojis.cli import get_commands, gitmojis_cli
 from gitmojis.model import Guide
+
+
+def test_get_commands_registers_command_from_commands_module(mocker):
+    @click.command()
+    def command():
+        pass
+
+    mocker.patch.dict(commands_module.__dict__, {"command": command})
+
+    commands = get_commands()
+
+    assert command in commands
 
 
 def test_gitmojis_cli_passes_guide_to_context(mocker, cli_runner):


### PR DESCRIPTION
## Description

This configures the package's command-line interface using [`click`][click].

In particular, the CLI is set up for adding commands. They can be defined in the `gitmojis.cli.commands` module to be then automatically registered in the main CLI hook.

Finally, the CLI is added to the package's entry points/scripts.

[click]: https://github.com/pallets/click