### PR TITLE
✨ Add a command to keep the backup up-to-date with the API

### DIFF
--- a/src/gitmojis/cli/commands.py
+++ b/src/gitmojis/cli/commands.py
@@ -1,0 +1,24 @@
+import json
+from dataclasses import asdict
+
+import click
+
+from gitmojis import defaults
+
+
+@click.command()
+@click.pass_context
+def sync(context: click.Context) -> None:
+    """Synchronize the backup file with the current state of the API."""
+    # Get the `Guide` object from the command's context
+    guide = context.obj["guide"]
+
+    # Covert the `Guide` instance from context to a format defined by the API schema
+    gitmojis_json = list(map(asdict, guide))
+
+    with defaults.GITMOJI_API_PATH.open("w", encoding="UTF-8") as f:
+        # Dump the Gitmoji data to the backup file
+        json.dump(gitmojis_json, f, ensure_ascii=False, indent=2)
+
+        # Append a newline to avoid the `end-of-file-fixer` Pre-commit hook error
+        f.write("\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 
 import click
+import requests
 
 from gitmojis.cli import commands as commands_module
 from gitmojis.cli import get_commands, gitmojis_cli
@@ -45,3 +46,19 @@ def test_gitmojis_cli_passes_guide_to_context(mocker, cli_runner):
     result = cli_runner.invoke(gitmojis_cli, "command")
 
     assert result.exit_code == 0
+
+
+def test_sync_command_dumps_api_data_to_backup_file(tmp_path, mocker, cli_runner):
+    # Mock the backup file as empty file
+    gitmoji_api_path = tmp_path / "gitmojis.json"
+    mocker.patch("gitmojis.defaults.GITMOJI_API_PATH", gitmoji_api_path)
+
+    # Mock response
+    response = mocker.Mock(spec_set=requests.Response)
+    response.json.return_value = {"gitmojis": []}
+    mocker.patch("requests.get", return_value=response)
+
+    # Run command
+    cli_runner.invoke(gitmojis_cli, ["sync"])
+
+    assert gitmoji_api_path.read_text(encoding="UTF-8") == "[]\n"


### PR DESCRIPTION
## Description

This defines the `gitmojis sync` command enabling synchronization the Gitmoji API with the package's backup file.

The up-to-date Gitmoji data are retrieved from the API using the function introduced in #9.