### PR TITLE
🧑‍💻 Set up the Markdown files linter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+
 ## Description
 
 <!--Provide a concise description of the changes made -->

--- a/.github/workflows/lint-markdown-files.yml
+++ b/.github/workflows/lint-markdown-files.yml
@@ -1,0 +1,26 @@
+name: Lint Markdown files
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '**.md'
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '**.md'
+
+jobs:
+  lint:
+    name: Lint Markdown files
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out 🎉
+      uses: actions/checkout@v4.1.1
+    - name: Run `markdownlint` 🎨
+      uses: DavidAnson/markdownlint-cli2-action@v13.0.0
+      with:
+        config: .markdownlint.jsonc
+        globs: '**/*.md'

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,23 @@
+// Full list of rules and their options available at:
+// https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.jsonc
+
+{
+  // Default state for all rules
+  "default": true,
+
+  // MD013/line-length - Line length
+  // https://github.com/DavidAnson/markdownlint/blob/main/doc/md013.md
+  "MD013": {
+    "line_length": 80,
+    "stern": true,
+    "tables": false
+  },
+
+  // MD014/commands-show-output - Dollar signs used before commands without showing output
+  // https://github.com/DavidAnson/markdownlint/blob/main/doc/md014.md
+  "MD014": false,
+
+  // MD043/required-headings/required-headers - Required heading structure
+  // https://github.com/DavidAnson/markdownlint/blob/main/doc/md043.md
+  "MD043": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
           - --no-ensure-ascii
           - --no-sort-keys
       - id: trailing-whitespace
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: 'v0.10.0'
+    hooks:
+    - id: markdownlint-cli2
   - repo: https://github.com/psf/black
     rev: '23.10.1'
     hooks:


### PR DESCRIPTION
## Description

This configures the Markdown file linter ([`markdownlint`][markdownlint] and related tools by D. Anson) as:

* a tool for local development;
* Pre-commit [hook][pre-commit];
* [GitHub Action] for validating the files in CI.

[gh-action]: https://github.com/DavidAnson/markdownlint-cli2-action
[markdownlint]: https://github.com/DavidAnson/markdownlint
[pre-commit]: https://github.com/DavidAnson/markdownlint-cli2
