### PR TITLE
🚩 Add `py.typed` marker file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ include = ["gitmojis*"]
 where = ["src"]
 
 [tool.setuptools.package-data]
-"gitmojis" = ["assets*"]
+"gitmojis" = ["py.typed", "assets*"]
 
 # Black
 # https://black.readthedocs.io/en/stable/usage_and_configuration/


### PR DESCRIPTION
## Description

This adds `py.typed` marker to distribute typing information, see [PEP 561][pep-561].

[pep-561]: https://peps.python.org/pep-0561/