### PR TITLE
👷 Add a workflow publishing the package to PyPI

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,80 @@
+name: Publish package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  get-release-tag:
+    name: Get the package version
+    runs-on: ubuntu-latest
+    outputs:
+      package-version: ${{ steps.package-version.outputs.package-version }}
+    steps:
+      - name: Check out 🎉
+        uses: actions/checkout@v4.1.1
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v4.7.1
+        with:
+          cache: pip
+      - name: Get the package version 🔖
+        id: package-version
+        run:
+          echo "package-version=$(python ./scripts/package_version.py)" >> "$GITHUB_OUTPUT"
+  pypi-publish:
+    needs: get-release-tag
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: PyPI
+      url: https://pypi.org/p/python-gitmojis
+    permissions:
+      id-token: write
+    steps:
+      - name: Check out 🎉
+        uses: actions/checkout@v4.1.1
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v4.7.1
+        with:
+          cache: pip
+      - name: Install PyPA `build` package 📦
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build the package 👷
+        run:
+          python -m build
+      - name: Publish to PyPI 🚀
+        uses: pypa/gh-action-pypi-publish@v1.8.10
+  create-release-tag:
+    needs:
+      - get-release-tag
+      - pypi-publish
+    name: Create the release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out 🎉
+        uses: actions/checkout@v4.1.1
+      - name: Create tag 🔖
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git tag "${{ needs.get-release-tag.outputs.package-version }}"
+          git push --tags
+  publish-release:
+    needs:
+      - get-release-tag
+      - create-release-tag
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out 🎉
+        uses: actions/checkout@v4.1.1
+      - name: Publish GitHub Release 📝
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          tag_name: ${{ needs.get-release-tag.outputs.package-version }}
+          generate_release_notes: true

--- a/scripts/package_version.py
+++ b/scripts/package_version.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+import tomllib
+
+
+def get_package_version() -> str:
+    """Return the package version from the `pyproject.toml` metadata."""
+    with (Path.cwd() / "pyproject.toml").open("rb") as pyproject_toml:
+        metadata = tomllib.load(pyproject_toml)
+    return metadata["project"]["version"]
+
+
+if __name__ == "__main__":
+    sys.stdout.write(get_package_version())


### PR DESCRIPTION
## Description

The workflow added:

1. uses a Python script to read the current version from `pyproject.toml`;
2. publishes the package to PyPI with [`gh-action-pypi-publish`][gh-action-pypi-publish] action;
3. creates a release tag;
4. publishes the package release in GitHub with [`action-gh-release`][action-gh-release].

[gh-action-pypi-publish]: https://github.com/pypa/gh-action-pypi-publish
[action-gh-release]: https://github.com/softprops/action-gh-release