### PR TITLE
✏️ Update invalid "ring bouy" emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ commit and pull request messages seem feasible as well.
 
 - Handle individual Gitmojis and their lists using Python classes. 👔
 - Fetch Gitmoji data directly from the official [Gitmoji API][gitmoji-api]. 😜
-- Graceful degradation: If the API is unavailable, fall back to backup data. 🛟
+- Graceful degradation: If the API is unavailable, fall back to backup data. 🦺
 
 ## Installation
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Description

This updates invalid "ring bouy" emoji in "Features" section of `README.md`.

Rendering of that emoji in Windows isn't supported.