### PR TITLE
✅ Fix exit code 2 in `gitmojis` CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,15 +8,14 @@ from gitmojis.cli import commands as commands_module
 from gitmojis.cli import get_commands, gitmojis_cli
 from gitmojis.model import Guide
 
-
 def test_gitmojis_cli_runs_as_entry_point():
-    result = subprocess.run(["gitmojis"])
+    result = subprocess.run(["gitmojis", "--version"])
 
     assert result.returncode == 0
 
 
 def test_gitmojis_cli_runs_as_python_script():
-    result = subprocess.run([sys.executable, "-m", "gitmojis"])
+    result = subprocess.run([sys.executable, "-m", "gitmojis", "--version"])
 
     assert result.returncode == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from gitmojis.cli import commands as commands_module
 from gitmojis.cli import get_commands, gitmojis_cli
 from gitmojis.model import Guide
 
+
 def test_gitmojis_cli_runs_as_entry_point():
     result = subprocess.run(["gitmojis", "--version"])
 


### PR DESCRIPTION
## Description

Testing CLI is updated to ensure exit code 0.

I guess this is due to pallets/click#1489 merged.

