### PR TITLE
👷 Remove macOS and Windows from CI test matrix

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -40,14 +40,7 @@ jobs:
           uv run nox -s ${{ matrix.session }}
   test:
     name: Run tests
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-      fail-fast: false
+    runs-on: ubuntu-latest
     steps:
       - name: Check out 🎉
         uses: actions/checkout@v4.2.2
@@ -62,7 +55,6 @@ jobs:
         run:
           uv run nox -s test
       - name: Upload coverage reports to Codecov ⛱️
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v5.4.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

Eliminate macOS and Windows from the CI test matrix, simplifying the testing process to only run on Ubuntu. 

## Linked issues

<!-- No linked issues -->

